### PR TITLE
Fixed some bugs in timestop

### DIFF
--- a/src/engine/ItemManager.java
+++ b/src/engine/ItemManager.java
@@ -194,6 +194,7 @@ public class ItemManager {
             }
         }
 
+
         return new SimpleEntry<>(addScore, addShipsDestroyed);
     }
 
@@ -228,6 +229,8 @@ public class ItemManager {
                 }
             }
         }
+
+
         return new SimpleEntry<>(addScore, addShipsDestroyed);
     }
 

--- a/src/entity/EnemyShipFormation.java
+++ b/src/entity/EnemyShipFormation.java
@@ -198,7 +198,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 	/**
 	 * Updates the position of the ships.
 	 */
-	public final void update() {
+	public final void update(boolean isTimestopActive) {
 		if(this.shootingCooldown == null) {
 			this.shootingCooldown = Core.getVariableCooldown(shootingInterval,
 					shootingVariance);
@@ -262,6 +262,13 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 				movementX = -X_SPEED;
 			else
 				movementY = Y_SPEED;
+
+
+			// Stop the movements of enemy ships when 'isTimeStopActive' is true.
+			if (isTimestopActive) {
+				movementX = 0;
+				movementY = 0;
+			}
 
 			positionX += movementX;
 			positionY += movementY;
@@ -357,10 +364,16 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 	 * @param bullets
 	 *            Bullets set to add the bullet being shot.
 	 */
-	public final void shoot(final Set<Bullet> bullets, int level) {
+	public final void shoot(final Set<Bullet> bullets, int level, boolean isTimeStopActive) {
 		// Increasing the number of projectiles per level 3 (levels 1 to 3, 4 to 6, 2, 7 to 9, etc.)
 		int numberOfShooters = Math.min((level / 3) + 1, this.shooters.size());
 		int numberOfBullets = (level / 3) + 1;
+
+		// Stop the attacks of enemy ships when 'isTimeStopActive' is true.
+		if (isTimeStopActive) {
+			numberOfShooters = 0;
+			numberOfBullets = 0;
+		}
 
 		// Randomly select enemy to fire in proportion to the level
 		List<EnemyShip> selectedShooters = new ArrayList<>();

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -370,13 +370,9 @@ public class GameScreen extends Screen {
 				this.logger.info("The special ship has escaped");
 			}
 
-			this.ship.update();
-
-			// If Time-stop is active, Stop updating enemy ships' move and their shoots.
-			if (!itemManager.isTimeStopActive()) {
-				this.enemyShipFormation.update();
-				this.enemyShipFormation.shoot(this.bullets, this.level);
-			}
+			// Stops the movements and attacks of enemy ships when 'isTimeStopActive' is true.
+			this.enemyShipFormation.update(itemManager.isTimeStopActive());
+			this.enemyShipFormation.shoot(this.bullets, this.level, itemManager.isTimeStopActive());
 
 			if (level >= 3) { //Events where vision obstructions appear start from level 3 onwards.
 				handleBlockerAppearance();


### PR DESCRIPTION
Fixed a bug where the bomb and linebomb were not triggered during 'timestop' activation.

Now, 'timestop' can stop the enemy's movements and attacks at the same time.

※ Restored item drop probability from previous commit. (100 => 30)

Added a boolean parameter to the update and shoot methods to control the movement and attack of enemies in the EnemyShipFormation.